### PR TITLE
update bindgen to 0.72.1 to fix build on aarch64-apple-darwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ localization = []
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = "0.72.1"
 cmake = "0.1.57"


### PR DESCRIPTION
bindgen 0.70.1 incorrectly generates opaque structs for _TidyAllocator, _TidyAllocatorVtbl, and _TidyBuffer, producing size assertions that overflow at compile time.

Fixes #2